### PR TITLE
fix: fix removing triggerChar

### DIFF
--- a/lib/adapters/autocomplete-adapter.ts
+++ b/lib/adapters/autocomplete-adapter.ts
@@ -103,7 +103,7 @@ export default class AutocompleteAdapter {
 
     // We must update the replacement prefix as characters are added and removed
     const cache = this._suggestionCache.get(server)!;
-    const replacementPrefix = request.editor.getTextInBufferRange([cache.triggerPoint, request.bufferPosition]);
+    const replacementPrefix = request.editor.getTextInBufferRange([cache.originalBufferPoint, request.bufferPosition]);
     for (const suggestion of suggestions) {
       if (suggestion.customReplacmentPrefix) { // having this property means a custom range was provided
         const len = replacementPrefix.length;

--- a/test/adapters/autocomplete-adapter.test.ts
+++ b/test/adapters/autocomplete-adapter.test.ts
@@ -483,6 +483,27 @@ describe('AutoCompleteAdapter', () => {
       result = (await autoCompleteAdapter.getSuggestions(server, customRequest))[0];
       expect(result.replacementPrefix).equals('#al');
     });
+
+    it('does not include the triggerChar in replacementPrefix', async () => {
+      const customRequest = createRequest({ prefix: '.', position: new Point(0, 4) });
+      customRequest.editor.setText('foo.');
+      server.capabilities.completionProvider!.triggerCharacters = ['.'];
+      sinon.stub(server.connection, 'completion').resolves([
+          createCompletionItem('bar'),
+      ]);
+      let result = (await autoCompleteAdapter.getSuggestions(server, customRequest))[0];
+      expect(result.replacementPrefix).equals('');
+      customRequest.editor.setTextInBufferRange([[0, 4], [0, 4]], 'b');
+      customRequest.prefix = 'b';
+      customRequest.bufferPosition = new Point(0, 5);
+      result = (await autoCompleteAdapter.getSuggestions(server, customRequest))[0];
+      expect(result.replacementPrefix).equals('b');
+      customRequest.editor.setTextInBufferRange([[0, 5], [0, 5]], 'a');
+      customRequest.prefix = 'ba';
+      customRequest.bufferPosition = new Point(0, 6);
+      result = (await autoCompleteAdapter.getSuggestions(server, customRequest))[0];
+      expect(result.replacementPrefix).equals('ba');
+    });
   });
 
   describe('completionKindToSuggestionType', () => {


### PR DESCRIPTION
fixes #99 

I can confirm this fixes replacing the trigger character in multiple autocomplete suggestion packages.

I don't know if this is just a bug from https://github.com/atom/atom-languageclient/pull/264 or if there was a reason `triggerPoint` was used. Perhaps @Aerijo might be able to give some insight?

~~I am also having some issues figuring out how to write a test for this.~~ I think I figured it out.