### PR TITLE
fix: kill and on exit signature match child_process

### DIFF
--- a/lib/server-manager.ts
+++ b/lib/server-manager.ts
@@ -23,9 +23,9 @@ export interface LanguageServerProcess extends EventEmitter {
   stderr: stream.Readable;
   pid: number;
 
-  kill(signal?: string): void;
+  kill(signal?: NodeJS.Signals | number): void;
   on(event: 'error', listener: (err: Error) => void): this;
-  on(event: 'exit', listener: (code: number, signal: string) => void): this;
+  on(event: 'exit', listener: (code: number, signal: NodeJS.Signals | number) => void): this;
 }
 
 /** The necessary elements for a server that has started or is starting. */


### PR DESCRIPTION
hello,

The signature of LanguageServerProcess interface is not following the signature from `child_process` standard library of Node. As a result, many current lsp implementation in atom-ide with this library does not follow the signature. E.g https://github.com/atom-ide-community/ide-python/blob/master/lib/main.js#L51