### PR TITLE
fix: set workspaceFolders to null when there is no workspace

### DIFF
--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -123,7 +123,7 @@ export default class AutoLanguageClient {
       processId: process.pid,
       rootPath: projectPath,
       rootUri: Convert.pathToUri(projectPath),
-      workspaceFolders: [],
+      workspaceFolders: null,
       capabilities: {
         workspace: {
           applyEdit: true,


### PR DESCRIPTION
Based on  https://microsoft.github.io/language-server-protocol/specifications/specification-current/#initialize
```ts

	/**
	 * The workspace folders configured in the client when the server starts.
	 * This property is only available if the client supports workspace folders.
	 * It can be `null` if the client supports workspace folders but none are
	 * configured.
	 *
	 * @since 3.6.0
	 */
	workspaceFolders?: WorkspaceFolder[] | null;
```


https://github.com/vuejs/vetur/issues/2561#issuecomment-743719403